### PR TITLE
updates singleFile to single-file-cli.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,9 @@ Example:
 
 ## Dependencies
 To run the program, you will need the following dependencies:  
+
+Install [Deno](https://docs.deno.com/runtime/getting_started/installation/).
+
 `pip install requests`  
 `pip install jsonpickle`  
 `pip install canvasapi`  

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "single-file": "github:gildas-lormeau/SingleFile"
+    "single-file-cli": "github:gildas-lormeau/single-file-cli"
   }
 }

--- a/singlefile.py
+++ b/singlefile.py
@@ -1,6 +1,6 @@
 from subprocess import run
 
-SINGLEFILE_BINARY_PATH = "./node_modules/single-file/cli/single-file"
+SINGLEFILE_BINARY_PATH = "./node_modules/single-file-cli/single-file"
 CHROME_PATH = "C:/Program Files/Google\ Chrome/Application/chrome.exe" #Uncomment this and set your browser exe if it can't find yours.
 
 def addQuotes(str):
@@ -19,7 +19,7 @@ def download_page(url, cookies_path, output_path, output_name_template = ""):
         args.append("--filename-template=" + addQuotes(output_name_template))
 
     try:
-        run("node " + " ".join(args), shell=True)
+        run(" ".join(args), shell=True)
     except Exception as e:
         print("Was not able to save the URL " + url + " using singlefile. The reported error was " + e.strerror)
 


### PR DESCRIPTION
Was running into a `MODULE_NOT_FOUND` running the script. 

Traced to a change in the structure of the [singleFile](https://github.com/gildas-lormeau/SingleFile) repo, which seems to have moved it's cli interface to [single-file-cli](https://github.com/gildas-lormeau/single-file-cli). 

Now requires a Deno install to work. Also, I wasn't able to get it working using the `node`, command, but running the binary directly appears to work. 