### PR TITLE
Check run errors in `singlefile.py`

### DIFF
--- a/singlefile.py
+++ b/singlefile.py
@@ -1,7 +1,7 @@
-from subprocess import run
+from subprocess import CalledProcessError, run
 
-SINGLEFILE_BINARY_PATH = "./node_modules/single-file-cli/single-file"
-CHROME_PATH = "C:/Program Files/Google\ Chrome/Application/chrome.exe" #Uncomment this and set your browser exe if it can't find yours.
+SINGLEFILE_BINARY_PATH = R"./node_modules/single-file-cli/single-file"
+CHROME_PATH = R"C:/Program Files/Google\ Chrome/Application/chrome.exe" #Uncomment this and set your browser exe if it can't find yours.
 
 def addQuotes(str):
     return "\"" + str.strip("\"") + "\""
@@ -19,9 +19,15 @@ def download_page(url, cookies_path, output_path, output_name_template = ""):
         args.append("--filename-template=" + addQuotes(output_name_template))
 
     try:
-        run(" ".join(args), shell=True)
+        cmd = " ".join(args)
+        print(cmd)
+        proc = run(cmd, shell=True, check=True, capture_output=True)
+        if stdout := proc.stdout.strip():
+            print(stdout)
+        if stderr := proc.stderr.strip():
+            raise CalledProcessError(proc.returncode, proc.args, output=stdout, stderr=stderr)
     except Exception as e:
-        print("Was not able to save the URL " + url + " using singlefile. The reported error was " + e.strerror)
+        print(f"Was not able to save the URL {url} using singlefile. The reported error was:", e)
 
 #if __name__ == "__main__":
     #download_page("https://www.google.com/", "", "./output/test", "test.html")


### PR DESCRIPTION
Using `run` without specifying `check=True` does not throw an exception if Chrome exits with a nonzero exit code.

Even if Chrome exits  with a zero exit code, the extension may still fail to save the page. When that happens, messages are printed to standard errors, so we should check for it too.